### PR TITLE
sync to dropwizards jackson version

### DIFF
--- a/pom.xml
+++ b/pom.xml
@@ -68,17 +68,17 @@
         <dependency>
             <groupId>com.fasterxml.jackson.core</groupId>
             <artifactId>jackson-core</artifactId>
-            <version>2.6.1</version>
+            <version>2.5.1</version>
         </dependency>
         <dependency>
             <groupId>com.fasterxml.jackson.core</groupId>
             <artifactId>jackson-databind</artifactId>
-            <version>2.6.1</version>
+            <version>2.5.1</version>
         </dependency>
         <dependency>
             <groupId>com.fasterxml.jackson.dataformat</groupId>
             <artifactId>jackson-dataformat-smile</artifactId>
-            <version>2.6.1</version>
+            <version>2.5.1</version>
         </dependency>
 
         <!-- serialization with jboss -->

--- a/pom.xml
+++ b/pom.xml
@@ -9,7 +9,7 @@
     </parent>
 
     <artifactId>jetty-session-redis</artifactId>
-    <version>2.6-SNAPSHOT</version>
+    <version>2.5.1-SNAPSHOT</version>
     <packaging>jar</packaging>
 
     <name>jetty-session-redis</name>

--- a/pom.xml
+++ b/pom.xml
@@ -9,7 +9,7 @@
     </parent>
 
     <artifactId>jetty-session-redis</artifactId>
-    <version>2.5-SNAPSHOT</version>
+    <version>2.6-SNAPSHOT</version>
     <packaging>jar</packaging>
 
     <name>jetty-session-redis</name>

--- a/src/main/java/com/ovea/jetty/session/serializer/JsonSerializer.java
+++ b/src/main/java/com/ovea/jetty/session/serializer/JsonSerializer.java
@@ -44,7 +44,7 @@ public final class JsonSerializer extends SerializerSkeleton {
     @Override
     public void start() {
         mapper = new ObjectMapper();
-        mapper.setVisibility(VisibilityChecker.Std.defaultInstance().withFieldVisibility(JsonAutoDetect.Visibility.ANY)
+        mapper.setVisibilityChecker(VisibilityChecker.Std.defaultInstance().withFieldVisibility(JsonAutoDetect.Visibility.ANY)
                 .withGetterVisibility(JsonAutoDetect.Visibility.NONE));
         mapper.configure(SerializationFeature.WRAP_ROOT_VALUE, false);
         mapper.configure(SerializationFeature.INDENT_OUTPUT, false);


### PR DESCRIPTION
needed for compatibility with version specified in angalia-api, which is pegged to the version used by dropwizard

@steve450 
